### PR TITLE
Add return value to #__vc_fc_files, fix specs

### DIFF
--- a/lib/view_component/fragment_caching/compilers/inherited_template_compilation.rb
+++ b/lib/view_component/fragment_caching/compilers/inherited_template_compilation.rb
@@ -23,6 +23,7 @@ module ViewComponent
 
             check_class = check_class.superclass
           end
+          templates
         end
 
         def __vc_fc_file_metadata(path)


### PR DESCRIPTION
Specs were failing, after some debugging we found that we needed to return `templates` on #__vc_fc_files. Specs are all green!