### PR TITLE
Update view component version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    view_component-fragment_caching (0.2.1)
+    view_component-fragment_caching (0.3.0)
       rails (~> 7.0)
       view_component (~> 3.9)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    view_component-fragment_caching (0.2.0)
+    view_component-fragment_caching (0.2.1)
       rails (~> 7.0)
-      view_component (~> 2.43)
+      view_component (~> 3.9)
 
 GEM
   remote: https://rubygems.org/
@@ -89,38 +89,36 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    date (3.3.4)
     diff-lcs (1.5.0)
-    digest (3.1.0)
     erubi (1.10.0)
-    globalid (1.0.0)
-      activesupport (>= 5.0)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
-    net-imap (0.2.3)
-      digest
+    net-imap (0.3.7)
+      date
       net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
+    net-pop (0.1.2)
       net-protocol
+    net-protocol (0.2.2)
       timeout
-    net-protocol (0.1.3)
-      timeout
-    net-smtp (0.3.1)
-      digest
+    net-smtp (0.4.0.1)
       net-protocol
-      timeout
-    nio4r (2.5.8)
+    nio4r (2.7.0)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -201,16 +199,16 @@ GEM
     rubocop-rspec (2.10.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    strscan (3.0.3)
     thor (1.2.1)
-    timeout (0.3.0)
+    timeout (0.4.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    view_component (2.57.0)
-      activesupport (>= 5.0.0, < 8.0)
+    view_component (3.9.0)
+      activesupport (>= 5.2.0, < 8.0)
+      concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
-    websocket-driver (0.7.5)
+    websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)

--- a/lib/view_component/fragment_caching/version.rb
+++ b/lib/view_component/fragment_caching/version.rb
@@ -1,6 +1,6 @@
 module ViewComponent
   module FragmentCaching
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.3.0'.freeze
     public_constant :VERSION
   end
 end

--- a/view_component-fragment_caching.gemspec
+++ b/view_component-fragment_caching.gemspec
@@ -22,7 +22,7 @@ require_relative 'lib/view_component/fragment_caching/version'
     end
 
   spec.add_dependency 'rails', '~> 7.0'
-  spec.add_dependency 'view_component', '~> 2.43'
+  spec.add_dependency 'view_component', '~> 3.9'
 
   spec.add_development_dependency 'capybara', '~> 3.36'
   spec.add_development_dependency 'pry-rails', '~> 0.3'


### PR DESCRIPTION
Thanks for this solution ! It's been a useful workaround for the missing support for fragment caching in the `ViewComponent` gem. However, a vulnerability has been found in `ViewComponent` versions <3.9, and the gem currently doesn't support the upgrade.

```bash
Name: view_component
Version: 2.82.0
CVE: CVE-2024-21636
GHSA: GHSA-wf2x-8w6j-qw37
Criticality: Medium
URL: <https://github.com/ViewComponent/view_component/security/advisories/GHSA-wf2x-8w6j-qw37>
Title: view_component Cross-site Scripting vulnerability
Solution: upgrade to '>= 3.9.0'

```

This updates the dependency version, and rebundles with ruby 2.7.2. Specs and rubocop passing.