### PR TITLE
Add compatibility with view component v3.21.0

### DIFF
--- a/lib/view_component/fragment_caching/digestors/with_view_component_rb.rb
+++ b/lib/view_component/fragment_caching/digestors/with_view_component_rb.rb
@@ -26,7 +26,7 @@ module ViewComponent
             end
 
             view_component_ancestors(component_class).map do |ancestor|
-              anc_identifier = ancestor.source_location
+              anc_identifier = ancestor.identifier
               anc_logical_name = ancestor.name.underscore
               view_component_ruby_node anc_identifier, anc_logical_name, template, klass
             end


### PR DESCRIPTION
v3.21.0 removes source_location but keeps the backward compatible and identical `identifier` use identifier in place of source_location