### PR TITLE
Bump `rails` in `gemspec` to `>= 7.0`

### DIFF
--- a/view_component-fragment_caching.gemspec
+++ b/view_component-fragment_caching.gemspec
@@ -21,7 +21,7 @@ require_relative 'lib/view_component/fragment_caching/version'
       ::Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
     end
 
-  spec.add_dependency 'rails', '~> 7.0'
+  spec.add_dependency 'rails', '>= 7.0.0'
   spec.add_dependency 'view_component', '~> 3.9'
 
   spec.add_development_dependency 'capybara', '~> 3.36'


### PR DESCRIPTION
Hey @patrickarnett, thanks for maintaining this gem!

I'm currently upgrading a Rails app from 7.2 to 8.0 and I noticed that the `view_component-fragment_caching` gem is locking the `rails` version to `~> 7.0`. This pull request bumps it to `>= 7.0` and it seems to work fine from what I can tell, which is why I'm opening this pull request. 

Let me know if you'd like to add an upper bound (like `< 9.0`) to the gemspec requirement as well.

Thank you!
